### PR TITLE
Fix: bookmark에 userid가 없어서 추가합니다

### DIFF
--- a/server/src/modules/bookmark/entities/bookmark.entity.ts
+++ b/server/src/modules/bookmark/entities/bookmark.entity.ts
@@ -20,6 +20,9 @@ export class Bookmark {
   @Column()
   order: number;
 
+  @Column()
+  userId: number;
+
   @ManyToOne(() => Folder, (folder) => folder.bookmarks)
   @JoinColumn({ name: 'folderId' })
   folder: Folder;


### PR DESCRIPTION
`bookmark.entity.ts`에 `userid`가 빠져있어 추가되고 있지않던 버그를 수정합니다