### PR TITLE
폴더 온오프 아이콘 추가

### DIFF
--- a/server/src/modules/bookmark/bookmark.service.ts
+++ b/server/src/modules/bookmark/bookmark.service.ts
@@ -146,4 +146,14 @@ export class BookmarkService {
       throw new InternalServerErrorException(error.message);
     }
   }
+
+  async findBookmarkCount(userId: number, folderId: number): Promise<number> {
+    return await this.bookmarkRepository
+      .createQueryBuilder('bookmark')
+      .select()
+      .where('bookmark.userId = :userId', { userId })
+      .andWhere('bookmark.folderId = :folderId', { folderId })
+      .andWhere('bookmark.deletedAt IS NULL')
+      .getCount();
+  }
 }

--- a/web/app/bookmarks/ChildFolderItem.tsx
+++ b/web/app/bookmarks/ChildFolderItem.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { FolderOutlined, MoreOutlined, PlusOutlined } from '@ant-design/icons';
+import {
+  CaretDownOutlined,
+  CaretRightOutlined,
+  FolderOutlined,
+  MoreOutlined,
+  PlusOutlined,
+} from '@ant-design/icons';
 import { Button, Dropdown, Flex, List, MenuProps, Space } from 'antd';
 import { Folder } from '@/app/lib/types/dataTypes';
 import BookmarkList from './BookmarkList';
@@ -31,7 +37,23 @@ export default function ChildFolderItem({ folder }: { folder: Folder }) {
   return (
     <List.Item>
       <List.Item.Meta
-        avatar={<FolderOutlined />}
+        avatar={
+          showChildren ? (
+            <Flex gap="4px">
+              <CaretDownOutlined
+                onClick={() => setShowChildren(prev => !prev)}
+              />
+              <FolderOutlined />
+            </Flex>
+          ) : (
+            <Flex gap="4px">
+              <CaretRightOutlined
+                onClick={() => setShowChildren(prev => !prev)}
+              />
+              <FolderOutlined />
+            </Flex>
+          )
+        }
         title={
           <Flex justify="space-between">
             <Space onClick={() => setShowChildren(prev => !prev)}>

--- a/web/app/bookmarks/ChildFolderItem.tsx
+++ b/web/app/bookmarks/ChildFolderItem.tsx
@@ -12,6 +12,7 @@ import BookmarkList from './BookmarkList';
 import EditFolderBtn from './EditFolderBtn';
 import DeleteFolderBtn from './DeleteFolderBtn';
 import AddChildBookmarkCBtn from './AddChildBookmarkBtn';
+import { folderCountStyle } from '../ui/folderPageStyles';
 
 export default function ChildFolderItem({ folder }: { folder: Folder }) {
   const [showChildren, setShowChildren] = useState(false);
@@ -40,16 +41,20 @@ export default function ChildFolderItem({ folder }: { folder: Folder }) {
         avatar={
           showChildren ? (
             <Flex gap="4px">
-              <CaretDownOutlined
-                onClick={() => setShowChildren(prev => !prev)}
-              />
+              {folder.subFolderCount + folder.bookmarkCount > 0 && (
+                <CaretDownOutlined
+                  onClick={() => setShowChildren(prev => !prev)}
+                />
+              )}
               <FolderOutlined />
             </Flex>
           ) : (
             <Flex gap="4px">
-              <CaretRightOutlined
-                onClick={() => setShowChildren(prev => !prev)}
-              />
+              {folder.subFolderCount + folder.bookmarkCount > 0 && (
+                <CaretRightOutlined
+                  onClick={() => setShowChildren(prev => !prev)}
+                />
+              )}
               <FolderOutlined />
             </Flex>
           )
@@ -58,6 +63,9 @@ export default function ChildFolderItem({ folder }: { folder: Folder }) {
           <Flex justify="space-between">
             <Space onClick={() => setShowChildren(prev => !prev)}>
               {folder.name}
+              {folder.bookmarkCount > 0 && (
+                <span style={folderCountStyle}>({folder.bookmarkCount})</span>
+              )}
             </Space>
             <Space direction="horizontal">
               <Dropdown

--- a/web/app/bookmarks/FolderItem.tsx
+++ b/web/app/bookmarks/FolderItem.tsx
@@ -8,7 +8,7 @@ import {
   PlusOutlined,
 } from '@ant-design/icons';
 import { Folder } from '@/app/lib/types/dataTypes';
-import { folderItemStyle } from '@/app/ui/folderPageStyles';
+import { folderCountStyle, folderItemStyle } from '@/app/ui/folderPageStyles';
 import EditFolderBtn from './EditFolderBtn';
 import DeleteFolderBtn from './DeleteFolderBtn';
 import BookmarkList from './BookmarkList';
@@ -46,14 +46,20 @@ export default function FolderItem({ folder }: { folder: Folder }) {
       avatar={
         showChildren ? (
           <Flex gap="4px">
-            <CaretDownOutlined onClick={() => setShowChildren(prev => !prev)} />
+            {folder.subFolderCount + folder.bookmarkCount > 0 && (
+              <CaretDownOutlined
+                onClick={() => setShowChildren(prev => !prev)}
+              />
+            )}
             <FolderOutlined />
           </Flex>
         ) : (
           <Flex gap="4px">
-            <CaretRightOutlined
-              onClick={() => setShowChildren(prev => !prev)}
-            />
+            {folder.subFolderCount + folder.bookmarkCount > 0 && (
+              <CaretRightOutlined
+                onClick={() => setShowChildren(prev => !prev)}
+              />
+            )}
             <FolderOutlined />
           </Flex>
         )
@@ -65,6 +71,9 @@ export default function FolderItem({ folder }: { folder: Folder }) {
             style={folderItemStyle}
           >
             {folder.name}
+            {folder.bookmarkCount > 0 && (
+              <span style={folderCountStyle}>({folder.bookmarkCount})</span>
+            )}
           </Space>
           <Space direction="horizontal">
             <Dropdown menu={{ items: folderAddableGruop }} trigger={['click']}>

--- a/web/app/bookmarks/FolderItem.tsx
+++ b/web/app/bookmarks/FolderItem.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 import { Button, Dropdown, Flex, List, MenuProps, Space } from 'antd';
-import { FolderOutlined, MoreOutlined, PlusOutlined } from '@ant-design/icons';
+import {
+  CaretDownOutlined,
+  CaretRightOutlined,
+  FolderOutlined,
+  MoreOutlined,
+  PlusOutlined,
+} from '@ant-design/icons';
 import { Folder } from '@/app/lib/types/dataTypes';
 import { folderItemStyle } from '@/app/ui/folderPageStyles';
 import EditFolderBtn from './EditFolderBtn';
@@ -37,7 +43,21 @@ export default function FolderItem({ folder }: { folder: Folder }) {
 
   return (
     <List.Item.Meta
-      avatar={<FolderOutlined />}
+      avatar={
+        showChildren ? (
+          <Flex gap="4px">
+            <CaretDownOutlined onClick={() => setShowChildren(prev => !prev)} />
+            <FolderOutlined />
+          </Flex>
+        ) : (
+          <Flex gap="4px">
+            <CaretRightOutlined
+              onClick={() => setShowChildren(prev => !prev)}
+            />
+            <FolderOutlined />
+          </Flex>
+        )
+      }
       title={
         <Flex justify="space-between">
           <Space

--- a/web/app/lib/types/dataTypes.ts
+++ b/web/app/lib/types/dataTypes.ts
@@ -5,6 +5,8 @@ export type Folder = {
   name: string;
   order: number;
   parentFolderId: Nullable<number>;
+  subFolderCount: number;
+  bookmarkCount: number;
   createdAt: Nullable<Date>;
   updatedAt: Nullable<Date>;
   deletedAt: Nullable<Date>;

--- a/web/app/ui/folderPageStyles.ts
+++ b/web/app/ui/folderPageStyles.ts
@@ -16,3 +16,8 @@ export const folderButtonStyle: React.CSSProperties = {
 export const folderListStyle: React.CSSProperties = {
   padding: '12px 20px 8px 20px',
 };
+
+export const folderCountStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: '#4263eb',
+};


### PR DESCRIPTION
<img width="659" alt="스크린샷 2024-08-02 오전 1 25 09" src="https://github.com/user-attachments/assets/efd89fd4-85c5-4b82-b3b9-f5274d8ed563">

하위폴더의 개수는 폴더의 온오프 아이콘

활성화하는곳에만 활용했고, 화면상에는 드러나지 않습니다.

북마크의 개수는 폴더이름 옆에 개수가 표시되는 디자인을 추가했습니다.